### PR TITLE
【|】修复指数分布抽样出错的问题

### DIFF
--- a/uncertainty2/src/UP2/SamplingMethod.py
+++ b/uncertainty2/src/UP2/SamplingMethod.py
@@ -46,7 +46,6 @@ class RandomSampling(SamplingMethod):
 class LHSampling(SamplingMethod):
     def get_sampling(self, size, type, *parm):
         if type == self.uniform:
-            print parm[0]
             return LHS.getSample(parm[0], parm[1], size)
 
 
@@ -66,7 +65,7 @@ class MonteCarloSampling(SamplingMethod):
             expression = '1.0/' + str(parm[0]) + '*np.e**(-1.0*x/' + str(parm[0]) + ')'
             # print expression
             # x落入(0, 5θ)的概率为1-e**(-5) (0.9933)
-            return MenteCarloMethod.getSample(expression, 0, 5*parm[1], size)
+            return MenteCarloMethod.getSample(expression, 0, 5*parm[0], size)
 
 # 具体策略类
 class Context(object):

--- a/uncertainty2/src/UP2/UPSelectMethodPanel.py
+++ b/uncertainty2/src/UP2/UPSelectMethodPanel.py
@@ -241,12 +241,17 @@ class SelectSamplingMethodPanel(wx.Panel):
         # 判断长度防止元祖越界
         result = 0
         #FIXME:情况不全
+        print(self.param.para[i])
         if len(self.param.para[i]) is 3:
             result = strategy[self.method_name[i]].GetResult(self.ssize[self.param.partype[i]], kind_dict[self.param.dtype[i]],
                                                          self.param.para[i][0], self.param.para[i][1], self.param.para[i][2])
-        if len(self.param.para[i]) is 2:
+        elif len(self.param.para[i]) is 2:
             result = strategy[self.method_name[i]].GetResult(self.ssize[self.param.partype[i]], kind_dict[self.param.dtype[i]],
                                                 self.param.para[i][0], self.param.para[i][1])
+        elif len(self.param.para[i]) is 1:
+            result = strategy[self.method_name[i]].GetResult(self.ssize[self.param.partype[i]],
+                                                             kind_dict[self.param.dtype[i]],
+                                                             self.param.para[i][0])
         self.type_result[self.param.partype[i]].append(result)
         self.results.append(result)
 


### PR DESCRIPTION
修复指数分布抽样出错的问题，由于每次都将参数转为float，所以任意分布的表达式不能传入。