### PR TITLE
【|】进一步完善设置参数

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 *.pyc
 workspace.xml
 other.xml
-uncertainty2/src/config.py

--- a/uncertainty2/src/ParamModeling/ParaSettingWindow.py
+++ b/uncertainty2/src/ParamModeling/ParaSettingWindow.py
@@ -2,6 +2,7 @@
 
 import wx
 import wx.xrc
+import config
 
 
 class ParaSettingWindow(wx.Dialog):
@@ -106,6 +107,10 @@ class ParaSettingWindow(wx.Dialog):
 
     def __del__(self):
         pass
+
+    def set_origin_info(self, info):
+        self.m_choice_kind.SetSelection(config.dis_index_set.get(info))
+        self.onChangeChoice(None)
 
     def onChangeChoice(self, event):
         self.m_textCtrl_p1.Clear()

--- a/uncertainty2/src/ParamModeling/ShowNotebook.py
+++ b/uncertainty2/src/ParamModeling/ShowNotebook.py
@@ -16,7 +16,7 @@ import ParaSettingWindow as psw
 class ShowNotebook(aui.AuiNotebook):
 
     # 用于存储ParaSettingWindow中设置的信息
-    para_info = 'fff'
+    para_info = 'para_info'
     
     def __init__(self, parent = None):
         
@@ -172,16 +172,21 @@ class ShowNotebook(aui.AuiNotebook):
         show_panel = self.GetCurrentPage()
         self.DeletePage(self.GetPageIndex(show_panel))
 
+    '''
     def ShowContent(self, event):
         show_panel = self.GetCurrentPage()
         print('-------------')
         for i in range(0, len(show_panel.params)):
             print(show_panel.grid.GetCellValue(i, 4))
         print('-------------')
+    '''
 
     def onSet(self, event):
+        show_panel = self.GetCurrentPage()
+        self.para_info = ''
         if event.GetCol() == 6:
             the_dialog = psw.ParaSettingWindow(self)
+            the_dialog.set_origin_info(show_panel.grid.GetCellValue(event.GetRow(), 4))
             the_dialog.ShowModal()
         else:
             return

--- a/uncertainty2/src/config.py
+++ b/uncertainty2/src/config.py
@@ -41,6 +41,13 @@ dis_type_set = {
     '任意分布': 'other'
 }
 
+dis_index_set = {
+    u'正态分布': 0,
+    u'均匀分布': 1,
+    u'指数分布': 2,
+    u'任意分布': 3
+}
+
 arg_type_get = OrderedDict([
             (0, '自变量'),
             (1, '固有不确定性参数'),


### PR DESCRIPTION
进一步完善设置参数，可以保持参数原本的分布类型，但是分布参数不能放到窗口中。